### PR TITLE
Specialist search on catalog with new query parser

### DIFF
--- a/lib/spectrum/request/requesty.rb
+++ b/lib/spectrum/request/requesty.rb
@@ -187,7 +187,7 @@ module Spectrum
 
       def new_parser_query(query_map = {}, filter_map = {})
         lp       = MLibrarySearchParser::Transformer::Solr::LocalParams.new(@psearch)
-        defaults = lp.config['search_atr_defaults'] || {}
+        defaults = lp.config['search_attr_defaults'] || {}
         base_query(query_map, filter_map).merge(defaults).merge(lp.params)
       end
 

--- a/lib/spectrum/response/specialists.rb
+++ b/lib/spectrum/response/specialists.rb
@@ -92,7 +92,8 @@ module Spectrum
           fq: query[:fq],
           qq: '"' + RSolr.solr_escape(query[:q]) + '"',
           rows: rows.first,
-          fl: fields.first
+          fl: fields.first,
+          df: query[:df] || 'allfields'
         )
         client.first.get('select', params: params)
       end
@@ -236,6 +237,9 @@ module Spectrum
           specialist_focus.facet_map
         )
         return [] if query[:q] == '*:*'
+        if query[:clean_string]
+          query[:q] = query[:clean_string]
+        end
         begin
           results = engines.map do |engine|
             engine.find(query)


### PR DESCRIPTION
This _appears_ to fix specialist search when only catalog is using the new query parser. Depends on https://github.com/mlibrary/mlibrary_search_parser/pull/15 being merged.