### PR TITLE
Add structured data to the error messages.

### DIFF
--- a/lib/spectrum/request/requesty.rb
+++ b/lib/spectrum/request/requesty.rb
@@ -46,14 +46,16 @@ module Spectrum
             @psearch = @builder.build(@data['raw_query'])
             @psearch.errors.each do |msg|
               @messages << Spectrum::Response::Message.error(
-                summary: "Query Parse Error: #{msg.class}",
-                details: msg.to_s
+                summary: "Query Parse Error",
+                details: msg.details,
+                data: msg.to_h
               )
             end
             @psearch.warnings.each do |msg|
               @messages << Spectrum::Response::Message.warn(
-                summary: "Query Parse Warning: #{msg.class}",
-                details: msg.to_s
+                summary: "Query Parse Warning",
+                details: msg.details,
+                data: msg.to_h,
               )
             end
           end

--- a/lib/spectrum/response/message.rb
+++ b/lib/spectrum/response/message.rb
@@ -9,6 +9,7 @@ module Spectrum
         @class = TYPES.include?(args[:class]) ? args[:class] : DEFAULT_TYPE
         @summary = args[:summary]
         @details = args[:details]
+        @data    = args[:data]
       end
 
       class << self
@@ -21,7 +22,7 @@ module Spectrum
       end
 
       def spectrum
-        { class: @class, summary: @summary, details: @details }
+        { class: @class, summary: @summary, details: @details, data: @data }
       end
     end
   end


### PR DESCRIPTION
Currently the error messages provided by the parser are passed in as just details + summary.

This change splits out into:
* `details`
* `summary` (no longer a part of the designs, iirc)
* The `actual` query run
* The `original` query provided.
The structured data is in a `data` attribute