### PR TITLE
Remove extraneous stuff from specialist query params

### DIFF
--- a/lib/spectrum/response/specialists.rb
+++ b/lib/spectrum/response/specialists.rb
@@ -88,11 +88,8 @@ module Spectrum
 
       def fetch_records(query)
         params = focus.first.solr_params.merge(query).merge(
-          q: query[:q],
-          fq: query[:fq],
           rows: rows.first,
-          fl: fields.first,
-          df: query[:df] || 'allfields'
+          fl: fields.first
         )
         client.first.get('select', params: params)
       end


### PR DESCRIPTION
Just a teeny-tiny change.

Now that we are merging the actual query into our solr params for the specialist search, we don't need to copy q, fq, and df from the query. We do need rows and fields, which are specific to specialist search.