### PR TITLE
Stop mixing in search_attr_defaults

### DIFF
--- a/lib/spectrum/request/requesty.rb
+++ b/lib/spectrum/request/requesty.rb
@@ -188,8 +188,7 @@ module Spectrum
 
       def new_parser_query(query_map = {}, filter_map = {}, built_search = @psearch)
         lp = MLibrarySearchParser::Transformer::Solr::LocalParams.new(built_search)
-        defaults = lp.config['search_attr_defaults'] || {}
-        base_query(query_map, filter_map).merge(defaults).merge(lp.params)
+        base_query(query_map, filter_map).merge(lp.params)
       end
 
       def base_query(query_map = {}, filter_map = {})


### PR DESCRIPTION
Because search_attr_defaults is how the edismax query gets its mm, etc., values, mixing it in at the top level means we end up with mm at the top level again, which breaks bools. Also we don't actually need it, because the request gets all the params it needs from query parser