### PR TITLE
updated item description to not try to show temp shelving location

### DIFF
--- a/lib/spectrum/entities/item.rb
+++ b/lib/spectrum/entities/item.rb
@@ -65,9 +65,6 @@ module Spectrum::Entities
     def temp_location?
       @item['temp_location'] 
     end
-    def temp_location
-      @item['temp_loc'] || ''
-    end
 
   end
   class HathiItem < GetHoldingsItem

--- a/lib/spectrum/holding/mirlyn_item_description.rb
+++ b/lib/spectrum/holding/mirlyn_item_description.rb
@@ -4,7 +4,6 @@ module Spectrum
       attr_reader :temp_location, :description
       def initialize(item:)
         @item = item
-        @temp_location = item.temp_location
         @description = item.description
       end
       def to_h
@@ -35,7 +34,7 @@ module Spectrum
       end
 
       def temp_location_string
-        "Temporary location: Shelved at #{@temp_location}"
+        "In a Temporary Location"
       end
 
       class TemporaryWithDescription < MirlynItemDescription

--- a/spec/spectrum/holding/mirlyn_item_description_spec.rb
+++ b/spec/spectrum/holding/mirlyn_item_description_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 describe Spectrum::Holding::MirlynItemDescription do
   context "to_h" do
     before(:each) do
-      @item_dbl = instance_double(Spectrum::Entities::MirlynItem, description: nil, temp_location?: false, temp_location: '')
+      @item_dbl = instance_double(Spectrum::Entities::MirlynItem, description: nil, temp_location?: false)
     end
     subject do 
       #only called with self.for
@@ -18,14 +18,12 @@ describe Spectrum::Holding::MirlynItemDescription do
     end
     it "returns only temp location" do
       allow(@item_dbl).to receive(:temp_location?).and_return(true)
-      allow(@item_dbl).to receive(:temp_location).and_return('MyTempLocation')
-      expect(subject).to eq({text: 'Temporary location: Shelved at MyTempLocation'})
+      expect(subject).to eq({text: 'In a Temporary Location'})
     end
     it "returns description and temp location" do
       allow(@item_dbl).to receive(:temp_location?).and_return(true)
-      allow(@item_dbl).to receive(:temp_location).and_return('MyTempLocation')
       allow(@item_dbl).to receive(:description).and_return('description')
-      expect(subject).to eq({html: '<div>description</div><div>Temporary location: Shelved at MyTempLocation</div>'})
+      expect(subject).to eq({html: '<div>description</div><div>In a Temporary Location</div>'})
     end
   end
 


### PR DESCRIPTION
Talked to Tim, and he said that "temp_loc" never has a value in getHoldings. This record is an example of the problem: https://search.lib.umich.edu/catalog/record/000598855 In the Shapiro Periodicals section. 

I changed it to say "In a Tempoary Location". Maybe it should say something else?