### PR TITLE
Fixes Flint Items not showing a Get This link

### DIFF
--- a/lib/spectrum/holding/no_action.rb
+++ b/lib/spectrum/holding/no_action.rb
@@ -1,7 +1,7 @@
 module Spectrum
   class Holding
     class NoAction < Action
-      def self.match?(item, contactless_pickup = ['HATCH','FINE','BUHR','SCI','SHAP','AAEL','MUSIC','OFFS','STATE'])
+      def self.match?(item, contactless_pickup = ['HATCH','FINE','BUHR','SCI','SHAP','AAEL','MUSIC','OFFS','STATE', 'FLINT'])
         open = contactless_pickup.concat(['SPEC','BENT','CLEM'])
         return true if !open.include?(item.library) 
 


### PR DESCRIPTION
Adds FLINT to the list of places participating in contactless pickup, which enables Flint Items to get a Get This link