### PR TITLE
SEARCH-1408-building-use-only-fix

### DIFF
--- a/lib/spectrum/decorators/physical_item_decorator.rb
+++ b/lib/spectrum/decorators/physical_item_decorator.rb
@@ -112,6 +112,9 @@ module Spectrum::Decorators
     def building_use_only?
       @item.item_policy == '08' #08 for Special Collections is also Reading Room Only
     end
+    def not_building_use_only?
+      !building_use_only?
+    end
     def not_pickup_or_checkout?
       not_pickup? || checked_out? || missing? || building_use_only?
     end

--- a/spec/spectrum/decorators/physical_item_decorator_spec.rb
+++ b/spec/spectrum/decorators/physical_item_decorator_spec.rb
@@ -145,6 +145,28 @@ describe Spectrum::Decorators::PhysicalItemDecorator do
       expect(subject.not_checked_out?).to eq(false)
     end
   end
+  context "building_use_only only item" do
+    before(:each) do
+      allow(@input[:solr_item]).to receive(:item_policy).and_return('08')
+    end
+    it "has true #building_use_only?" do
+      expect(subject.building_use_only?).to eq(true)
+    end
+    it "has false #not_building_use_only?" do
+      expect(subject.not_building_use_only?).to eq(false)
+    end
+  end
+  context "not building_use_only item" do
+    before(:each) do
+      allow(@input[:solr_item]).to receive(:item_policy).and_return('01')
+    end
+    it "has false #building_use_only?" do
+      expect(subject.building_use_only?).to eq(false)
+    end
+    it "has true #not_building_use_only?" do
+      expect(subject.not_building_use_only?).to eq(true)
+    end
+  end
   context "#not_pickup_or_checkout?" do
     it "is true if item is not in any of the pickup locations" do
       allow(@input[:solr_item]).to receive(:library).and_return('BSTA')


### PR DESCRIPTION
This adds a `#not_building_use`_only method to `PhysicalItemDecorator`. It can be merged independently from the corresponding spectrum PR. 